### PR TITLE
Fix parsing filter

### DIFF
--- a/lib/parsing/parseFilter.js
+++ b/lib/parsing/parseFilter.js
@@ -62,6 +62,7 @@ function parseFilter (filter, options = {}) {
               warning && logger.warn(warning)
             }
             parsed[parseAttributeName(name)] = {
+              ...(parsed[parseAttributeName(name)] || {}),
               [operator]: operativeValue,
             }
           } else {


### PR DESCRIPTION
filter に二つ以上のオペレータを指定すると一つしかパースされなかったのを修正。
